### PR TITLE
unecessary buttons appear later

### DIFF
--- a/Poker/GameLogic/Monte_Carlo_Probability_Simulator.cpp
+++ b/Poker/GameLogic/Monte_Carlo_Probability_Simulator.cpp
@@ -1,6 +1,6 @@
 #include "Monte_Carlo_Probability_Simulator.hpp"
 // function that for any given hand, number of current players, state of the table, computes the probability of winning, making draws or losing
-#include <//qDebug.h>
+
 
 
 std::vector<float> Winning_Probability (Table &table, std::vector<Card> &hand, int num_players, int num_simulations) { //num_players is the number of other players

--- a/Poker/Visuals/Gamewindow/gamewindow.cpp
+++ b/Poker/Visuals/Gamewindow/gamewindow.cpp
@@ -81,7 +81,6 @@ GameWindow::GameWindow(QWidget *parent, std::string name) : game_player(name),
         }
     }
 
-    switch_bet_button_off();
 
     // Add labels to the layout
     verticalLayout->addWidget(labelPot);
@@ -90,7 +89,7 @@ GameWindow::GameWindow(QWidget *parent, std::string name) : game_player(name),
     labelPot->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     //hide bet buttons
-    switch_bet_button_off();
+    switch_bet_button_off_start();
 
 
 
@@ -412,6 +411,10 @@ void GameWindow::switch_bet_button_on(){
     ui->RaiseButton->show();
     ui->FoldButton->show() ;
     ui->CallButton->show();
+    ui->Preflop_odds->show();
+    ui->hand_display->show();
+    ui->raise_box->show();
+    ui->cumulative_bet_line->show();
 }
 
 /*
@@ -424,6 +427,17 @@ void GameWindow::switch_bet_button_off(){
     ui->FoldButton->hide() ;
     ui->CallButton->hide();
 }
+
+void GameWindow::switch_bet_button_off_start(){
+    ui->RaiseButton->hide();
+    ui->FoldButton->hide() ;
+    ui->CallButton->hide();
+    ui->Preflop_odds->hide();
+    ui->hand_display->hide();
+    ui->raise_box->hide();
+    ui->cumulative_bet_line->hide();
+}
+
 
 
 /*

--- a/Poker/Visuals/Gamewindow/gamewindow.hpp
+++ b/Poker/Visuals/Gamewindow/gamewindow.hpp
@@ -34,6 +34,7 @@ public:
     void display_player_hand();
     void switch_bet_button_on();
     void switch_bet_button_off();
+    void switch_bet_button_off_start();
     void switch_players_display();
     void display_middle_pot();
     void display_given_cards(PokerPlayer* display_player);


### PR DESCRIPTION
idk if this is useful but i think it's a bit better. Not a big deal. It makes it so the odds display, the 'high card'/'pair'/ other and the button to raise appear only when the first game starts.